### PR TITLE
Size Metrics Test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -189,7 +189,7 @@ dependencies {
     implementation(libs.firebase.crashlytics.ndk)
     implementation(libs.firebase.performance)
 
-    implementation(libs.barcode)
+    implementation("com.google.android.gms:play-services-ads:22.1.0")
 
     testImplementation(libs.junit4)
     androidTestImplementation(libs.androidx.test.ext)


### PR DESCRIPTION
- `barcode` dependency replaced with `play-services-ads` to test the updates in `size_metrics` workflow